### PR TITLE
Add environment variables for newly minted creds requirement

### DIFF
--- a/tests/test_trello_discovery.py
+++ b/tests/test_trello_discovery.py
@@ -6,7 +6,12 @@ import unittest
 
 class TestTrelloDiscovery(unittest.TestCase):
     def setUp(self):
-        missing_envs = [x for x in [] if os.getenv(x) == None]
+        missing_envs = [x for x in [
+            "TAP_TRELLO_CONSUMER_KEY",
+            "TAP_TRELLO_CONSUMER_SECRET",
+            "TAP_TRELLO_ACCESS_TOKEN",
+            "TAP_TRELLO_ACCESS_TOKEN_SECRET",
+        ] if os.getenv(x) == None]
         if len(missing_envs) != 0:
             raise Exception("Missing environment variables: {}".format(missing_envs))
 
@@ -17,7 +22,12 @@ class TestTrelloDiscovery(unittest.TestCase):
         return "platform.trello"
 
     def get_credentials(self):
-        return {}
+        return {
+            'consumer_key': os.getenv('TAP_TRELLO_CONSUMER_KEY'),
+            'consumer_secret': os.getenv('TAP_TRELLO_CONSUMER_SECRET'),
+            'access_token': os.getenv('TAP_TRELLO_ACCESS_TOKEN'),
+            'access_token_secret': os.getenv('TAP_TRELLO_ACCESS_TOKEN_SECRET'),
+        }
 
     def expected_check_streams(self):
         return {


### PR DESCRIPTION
# Description of change
This PR modifies the existing integration test to use the environment credentials to make requests.

# Manual QA steps
 - Ran locally with creds.
 
# Risks
 - Low, it's purely tests.
 
# Rollback steps
 - revert this branch
