### PR TITLE
Add to JSON Schemas and update query params for test_utils

### DIFF
--- a/tap_trello/schemas/boards.json
+++ b/tap_trello/schemas/boards.json
@@ -147,6 +147,42 @@
         "string"
       ]
     },
+    "powerUps": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "premiumFeatures": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "idTags": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "prefs": {
       "type": [
         "null",

--- a/tap_trello/schemas/cards.json
+++ b/tap_trello/schemas/cards.json
@@ -92,6 +92,18 @@
         }
       }
     },
+    "idMembersVoted": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "checkItemStates": {
       "type": [
         "null",

--- a/tests/test_trello_bookmarks_qa.py
+++ b/tests/test_trello_bookmarks_qa.py
@@ -275,12 +275,7 @@ class TrelloBookmarksQA(unittest.TestCase):
                 data_2 = synced_records_2.get(stream, [])
                 record_messages_2 = [row.get('data') for row in data_2['messages']]
                 record_ids_2 = set(row.get('data').get('id') for row in data_2['messages'])
-                # WORKAROUND for bug below
-                field_discrepancies = { # missing from: a = actual, e = expected | a is BAD
-                    'checklists': {'limits','creationMethod'},# missing from: e, e
-                    'boards': {'powerUps', 'idTags', 'premiumFeatures'}, # missing from: a, a, a
-                    'cards': {'customFieldItems', 'idMembersVoted'}, # missing from: e, a
-                }
+
                 # verify all expected records are replicated for both syncs
                 self.assertEqual(expected_ids_1, record_ids_1,
                                  msg="Data discrepancy. Expected records do not match actual in sync 1.")
@@ -290,19 +285,8 @@ class TrelloBookmarksQA(unittest.TestCase):
                 for expected_record in expected_records_1.get(stream):
                     actual_record = [message for message in record_messages_1
                                      if message.get('id') == expected_record.get('id')].pop()
-
-                    # BUG | https://stitchdata.atlassian.net/browse/SRCE-3282
-                    # verify all expected fields are replicated for a given record # WORKAROUND
-                    if set(expected_record.keys()) != set(actual_record.keys()):
-                        actual_minus_expected = set(actual_record.keys()).difference(set(expected_record.keys()))
-                        if actual_minus_expected.issubset(field_discrepancies.get(stream)):
-                            print("KNOWN FIELD DISCREPANCY | stream: {} | field(s): {} ".format(stream, actual_minus_expected))
-                        else:
-                            self.assertEqual(set(expected_record.keys()), set(actual_record.keys()),
-                                             msg="Field mismatch between expectations and replicated records in sync 1.")
-                    # verify all expected fields are replicated for a given record # TODO put back when bug addressed
-                    # self.assertEqual(set(expected_record.keys()), set(actual_record.keys()),
-                    #                  msg="Field mismatch between expectations and replicated records in sync 1.")
+                    self.assertEqual(set(expected_record.keys()), set(actual_record.keys()),
+                                     msg="Field mismatch between expectations and replicated records in sync 1.")
 
                 # verify the 2nd sync gets records created after the 1st sync
                 self.assertEqual(set(record_ids_2).difference(set(record_ids_1)),

--- a/tests/trello_utils.py
+++ b/tests/trello_utils.py
@@ -114,6 +114,10 @@ def get_objects(obj_type: str, obj_id: str = "", parent_id: str = "", since = No
     if since:
         parameters = PARAMS + (('since', since),)
 
+    if obj_type == 'checklists':
+        parameters += (('fields', 'all'),)
+        parameters += (('checkItem_fields', 'all'),)
+
     resp = requests.get(url=endpoint, headers=HEADERS, params=parameters)
     if resp.status_code >= 400:
         logging.warn("Request Failed {} \n    {}".format(resp.status_code, resp.text))
@@ -136,7 +140,7 @@ def get_objects_cards(obj_type="cards", obj_id: str = "", parent_id: str = "", s
             raise Exception("Must specify an obj_id to acquire customFields")
         endpoint = BASE_URL + "/{}/{}/customFieldItems".format(obj_type, obj_id)
 
-    parameters = PARAMS
+    parameters = PARAMS + (('customFieldItems','true'),('limit',20000))
     if since:
         parameters = PARAMS + (('since', since),)
 


### PR DESCRIPTION
# Description of change

Fixes a bug in the tests where we were missing fields in the JSON schema and not providing the correct query-params for some of the GETs that the utils issue.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
