### PR TITLE
TDL-16246: Make MAX_API_RESPONSE_SIZE configurable and add pagination for card stream.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-trello/bin/activate
-            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,consider-using-f-string'
+            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,consider-using-f-string,unspecified-encoding'
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-trello/bin/activate
-            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
+            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,consider-using-f-string'
       - run:
           name: 'Integration Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-trello/bin/activate
             pip install coverage
-            nosetests --with-coverage --cover-erase --cover-package=tap_trelo --cover-html-dir=htmlcov tests/unittests
+            nosetests --with-coverage --cover-erase --cover-package=tap_trello --cover-html-dir=htmlcov tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-trello/bin/activate
-            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,consider-using-f-string,unspecified-encoding'
+            pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,consider-using-f-string,unspecified-encoding'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,17 @@ jobs:
             source /usr/local/share/virtualenvs/tap-trello/bin/activate
             pylint tap_trello --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,consider-using-f-string,unspecified-encoding'
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-trello/bin/activate
+            pip install coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_trelo --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/tap_trello/__init__.py
+++ b/tap_trello/__init__.py
@@ -3,7 +3,7 @@ from singer import utils
 from singer.catalog import Catalog, write_catalog
 from tap_trello.discover import do_discover
 from tap_trello.sync import do_sync
-import tap_trello.streams as streams
+from tap_trello import streams
 from tap_trello.client import TrelloClient
 
 LOGGER = singer.get_logger()

--- a/tap_trello/client.py
+++ b/tap_trello/client.py
@@ -37,7 +37,7 @@ class TrelloClient():
         # NB: There are headers defining Trello version and Trello
         # environment (e.g., Production) here, might be useful in the
         # future. At initial development, version is 1.2083.0
-        response = requests.request(method, full_url, headers=headers, params=params, auth=self.oauth)
+        response = requests.request(method, full_url, headers=headers, params=params, auth=self.oauth, timeout=1800)
 
         response.raise_for_status()
         # TODO: Check error status, rate limit, etc.

--- a/tap_trello/discover.py
+++ b/tap_trello/discover.py
@@ -17,7 +17,7 @@ def _load_schemas():
     for filename in os.listdir(_get_abs_path("schemas")):
         path = _get_abs_path("schemas") + "/" + filename
         file_raw = filename.replace(".json", "")
-        with open(path, encoding="utf8") as file:
+        with open(path) as file:
             schemas[file_raw] = json.load(file)
 
     return schemas

--- a/tap_trello/discover.py
+++ b/tap_trello/discover.py
@@ -17,7 +17,7 @@ def _load_schemas():
     for filename in os.listdir(_get_abs_path("schemas")):
         path = _get_abs_path("schemas") + "/" + filename
         file_raw = filename.replace(".json", "")
-        with open(path) as file:
+        with open(path, encoding="utf8") as file:
             schemas[file_raw] = json.load(file)
 
     return schemas

--- a/tap_trello/streams.py
+++ b/tap_trello/streams.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from itertools import dropwhile
+import operator
 import singer
-
 from singer import utils
 
 LOGGER = singer.get_logger()
@@ -20,9 +20,9 @@ class OrderChecker:
         Actions, this ensures that this holds up.
         """
         if self.order == 'ASC':
-            check_paired_order = lambda a, b: a < b
+            check_paired_order = operator.lt
         else:
-            check_paired_order = lambda a, b: a > b
+            check_paired_order = operator.gt
 
         if self._last_value is None:
             self._last_value = current_value
@@ -228,7 +228,7 @@ class Stream:
             yield rec
 
 class AddCustomFields(Mixin):
-    def _get_dropdown_option_key(self, field_id, option_id): # pylint: disable=no-self-use
+    def _get_dropdown_option_key(self, field_id, option_id):
         return field_id + '_' + option_id
 
     def build_custom_fields_maps(self, **kwargs):
@@ -249,7 +249,7 @@ class AddCustomFields(Mixin):
         return custom_fields_map, dropdown_options_map
 
 
-    def modify_record(self, record, **kwargs): # pylint: disable=no-self-use
+    def modify_record(self, record, **kwargs):
         custom_fields_map = kwargs['custom_fields_map']
         dropdown_options_map = kwargs['dropdown_options_map']
         for custom_field in record['customFieldItems']:
@@ -263,7 +263,7 @@ class AddCustomFields(Mixin):
 
 
 class AddBoardId(Mixin):
-    def modify_record(self, record, **kwargs): # pylint: disable=no-self-use
+    def modify_record(self, record, **kwargs):
         boardIdList = kwargs['parent_id_list']
         assert len(boardIdList) == 1
         record["boardId"] = boardIdList[0]
@@ -282,7 +282,7 @@ class ChildStream(Stream):
         for parent_obj in parent.get_records(parent.get_format_values(), additional_params={"fields": "id"}):
             yield parent_obj['id']
 
-    def _sort_parent_ids_by_created(self, parent_ids): # pylint: disable=no-self-use
+    def _sort_parent_ids_by_created(self, parent_ids):
         # NB This is documented here. Yes it's hacky
         # - https://help.trello.com/article/759-getting-the-time-a-card-or-board-was-created
         parents = [{"id": x, "created": datetime.utcfromtimestamp(int(x[:8], 16))}

--- a/tap_trello/streams.py
+++ b/tap_trello/streams.py
@@ -374,8 +374,8 @@ class Cards(AddCustomFields, ChildStream):
     replication_method = "FULL_TABLE"
     parent_class = Boards
     MAX_API_RESPONSE_SIZE = 1000
-    
-    def get_records(self, format_values):
+
+    def get_records(self, format_values, additional_params=None):
         # Get max_api_response_size from config and set to paramater
         response_size = self.config.get('max_api_response_size_card')
         if response_size and int(response_size):
@@ -388,12 +388,12 @@ class Cards(AddCustomFields, ChildStream):
         custom_fields_map, dropdown_options_map = self.build_custom_fields_maps(parent_id_list=format_values)
         while True:
 
-            # Get records for cards before specified time or card ID 
+            # Get records for cards before specified time or card ID
             records = self.client.get(self._format_endpoint(format_values), params={"before": window_end,
                                                                                     **self.params})
             for rec in records:
                 yield self.modify_record(rec, parent_id_list = format_values, custom_fields_map = custom_fields_map, dropdown_options_map = dropdown_options_map)
-            
+
             # If records are same as limit then shift window to get older data
             if len(records) == self.MAX_API_RESPONSE_SIZE:
                 LOGGER.info("%s - Collected  %s records for board %s.",
@@ -413,11 +413,11 @@ class Cards(AddCustomFields, ChildStream):
                         self.MAX_API_RESPONSE_SIZE)
                 )
             else:
+                # API returns less records than limit, break the pagination
                 LOGGER.info("%s - Collected  %s records for board %s.",
                             self.stream_id,
                             len(records),
                             format_values[0])
-                # API returns less records than limit, break the pagination 
                 break
 
 class Checklists(ChildStream):

--- a/tap_trello/streams.py
+++ b/tap_trello/streams.py
@@ -388,8 +388,8 @@ class Cards(AddCustomFields, ChildStream):
         custom_fields_map, dropdown_options_map = self.build_custom_fields_maps(parent_id_list=format_values)
         while True:
 
-            # Get records for cards before specified time or card ID trello we use standard Mongo IDs,
-            # so we can pass Card ID as trello we will derive the date from it.
+            # Get records for cards before specified time or card ID
+            # Trello use standard Mongo IDs so we can pass Card ID as trello will derive the date from it.
             # Reference: https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/#paging
             records = self.client.get(self._format_endpoint(format_values), params={"before": window_end,
                                                                                     **self.params})

--- a/tap_trello/streams.py
+++ b/tap_trello/streams.py
@@ -184,16 +184,16 @@ class Stream:
         self.state = state
 
 
-    def get_format_values(self): # pylint: disable=no-self-use
+    def get_format_values(self):
         return []
 
     def _format_endpoint(self, format_values):
         return self.endpoint.format(*format_values)
 
-    def modify_record(self, record, **kwargs): # pylint: disable=no-self-use,unused-argument
+    def modify_record(self, record, **kwargs): # pylint: disable=unused-argument
         return record
 
-    def build_custom_fields_maps(self, **kwargs): # pylint: disable=no-self-use,unused-argument
+    def build_custom_fields_maps(self, **kwargs): # pylint: disable=unused-argument
         return {}, {}
 
     def get_records(self, format_values, additional_params=None):

--- a/tap_trello/streams.py
+++ b/tap_trello/streams.py
@@ -376,7 +376,7 @@ class Cards(AddCustomFields, ChildStream):
     MAX_API_RESPONSE_SIZE = 1000
 
     def get_records(self, format_values, additional_params=None):
-        # Get max_api_response_size from config and set to paramater
+        # Get max_api_response_size from config and set to parameter
         response_size = self.config.get('max_api_response_size_card')
         if response_size and int(response_size):
             self.MAX_API_RESPONSE_SIZE = int(response_size)
@@ -388,7 +388,9 @@ class Cards(AddCustomFields, ChildStream):
         custom_fields_map, dropdown_options_map = self.build_custom_fields_maps(parent_id_list=format_values)
         while True:
 
-            # Get records for cards before specified time or card ID
+            # Get records for cards before specified time or card ID trello we use standard Mongo IDs,
+            # so we can pass Card ID as trello we will derive the date from it.
+            # Reference: https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/#paging
             records = self.client.get(self._format_endpoint(format_values), params={"before": window_end,
                                                                                     **self.params})
             for rec in records:
@@ -403,7 +405,7 @@ class Cards(AddCustomFields, ChildStream):
 
                 # Sort cards based on card ID as API returns latest records but in unorder manner
                 records = sorted(records, key=lambda x: x['id'])
-                # API returns latest records so set sub_window_end to smallest card id to get older data
+                # API returns latest records so set window_end to smallest card id to get older data
                 window_end = records[0]["id"]
 
             elif self.MAX_API_RESPONSE_SIZE and len(records) > self.MAX_API_RESPONSE_SIZE:

--- a/tests/test_trello_bookmarks_qa.py
+++ b/tests/test_trello_bookmarks_qa.py
@@ -289,8 +289,12 @@ class TrelloBookmarksQA(unittest.TestCase):
                                          if message.get('id') == expected_record.get('id')].pop()
                         actual_fields = set(actual_record.keys())
                         expected_fields = set(expected_record.keys())
-                        if stream == 'cards':  # BUG (https://stitchdata.atlassian.net/browse/SRCE-4487)
-                            expected_fields.remove('cardRole')  # Remove when addressed
+                        # BUG https://jira.talendforge.org/browse/TDL-9680
+                        # BUG https://jira.talendforge.org/browse/TDL-20813
+                        if stream == 'cards':
+                            # Remove when addressed
+                            for field in ('cardRole', 'email'):
+                                expected_fields.remove(field)
                         self.assertEqual(expected_fields, actual_fields,
                                          msg="Field mismatch between expectations and replicated records in sync 1.")
 

--- a/tests/test_trello_pagination.py
+++ b/tests/test_trello_pagination.py
@@ -40,7 +40,7 @@ class TestTrelloPagination(unittest.TestCase):
             'consumer_secret': os.getenv('TAP_TRELLO_CONSUMER_SECRET'),
             'access_token': os.getenv('TAP_TRELLO_ACCESS_TOKEN'),
             'access_token_secret': os.getenv('TAP_TRELLO_ACCESS_TOKEN_SECRET'),
-            'max_api_response_size_card': 50 # Configurable pagination limit for card stream
+            'cards_response_size': 50 # Configurable pagination limit for card stream
         }
 
     def testable_streams(self):

--- a/tests/test_trello_start_date.py
+++ b/tests/test_trello_start_date.py
@@ -260,17 +260,18 @@ class TestTrelloStartDate(unittest.TestCase):
         ##########################################################################
         syncing_incremental = False
         for stream in self.testable_streams():
-            if utils.get_replication_method(stream) == self.INCREMENTAL:
-                # Verify the 1st sync replicated less data than the 2nd if syncing inc streams
-                self.assertGreater(replicated_row_count_2, replicated_row_count_1,
-                                   msg="we replicated less data with an older start date\n" +
-                                   "------------------------------\n" +
-                                   "Start Date 1: {} ".format(start_date_1) +
-                                   "Row Count 1: {}\n".format(replicated_row_count_1) +
-                                   "------------------------------\n" +
-                                   "Start Date 2: {} ".format(start_date_2) +
-                                   "Row Count 2: {}\n".format(replicated_row_count_2))
-                syncing_incremental = True
+            with self.subTest(stream=stream):
+                if utils.get_replication_method(stream) == self.INCREMENTAL:
+                    # Verify the 1st sync replicated less data than the 2nd if syncing inc streams
+                    self.assertGreater(replicated_row_count_2, replicated_row_count_1,
+                                       msg="we replicated less data with an older start date\n" +
+                                       "------------------------------\n" +
+                                       "Start Date 1: {} ".format(start_date_1) +
+                                       "Row Count 1: {}\n".format(replicated_row_count_1) +
+                                       "------------------------------\n" +
+                                       "Start Date 2: {} ".format(start_date_2) +
+                                       "Row Count 2: {}\n".format(replicated_row_count_2))
+                    syncing_incremental = True
 
         if not syncing_incremental:
             # Verify the 1st and 2nd sync replicated the same number of records if not syncing inc streams

--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -1,102 +1,113 @@
 import unittest
 from unittest import mock
-from unittest.mock import Mock
-import requests
 from unittest.case import TestCase
-from tap_trello.client import LOGGER, TrelloClient
+from tap_trello.client import TrelloClient
 from tap_trello.streams import Cards
 
+
+DEFAULT_CONFIG = {
+    "start_date": "dummy_st",
+    "access_token": "dummy_at",
+    "access_token_secret": "dummy_as",
+    "consumer_key": "dummy_ck",
+    "consumer_secret": "dummy_cs",
+}
+
 @mock.patch('tap_trello.client.requests.request')
-class TestMaxAPIResponseSizeValue(unittest.TestCase):
+class TestCardsResponseSizeValue(unittest.TestCase):
     '''
-    Test that the max_api_response_size param is set correctly based on different config values
+    Test that the cards_response_size param is set correctly based on different config values
     '''
+
+    def setUp(self):
+        '''Reset the response size to a value in every test'''
+        # This is the default in the tap
+        self.expected_response_size = 1000
+
     def test_param_value_from_config_for_cards(self, mock_request):
         '''
-        Test that when config parameter `cards_response_size` is passed the params is set correctly from the config value
+        Test that when the config param `cards_response_size` is passed, it is used
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 200}
+        self.expected_response_size = 200
+        config = {**DEFAULT_CONFIG, "cards_response_size": self.expected_response_size}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 200)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_default_param_value_for_cards(self, mock_request):
         '''
-        Test that when no config value is provided for `cards_response_size`, then default is taken as 1000
+        Test that when no config value is provided for the config param `cards_response_size`, then
+        the default is used
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs"}
-        client = TrelloClient(config)
-        card = Cards(client, config, {})
+        client = TrelloClient(DEFAULT_CONFIG)
+        card = Cards(client, DEFAULT_CONFIG, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_empty_string_in_config(self, mock_request):
         '''
-        Test that when empty string value is provided for the config param `cards_response_size`, the default
-        value is taken and passed as 5000
+        Test that when empty string value is provided for the config param `cards_response_size`, 
+        the default value is used
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": ""}
+        config = {**DEFAULT_CONFIG, "cards_response_size": ""}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_string_value_in_config(self, mock_request):
         '''
-        Test that when a string value is passe in the config param `cards_response_size`, it is converted to integer
-        and then passed
+        Test that when a string value is passed in the config param `cards_response_size`, it is 
+        converted to integer and then used
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": "300"}
+        self.expected_response_size = 300
+        config = {**DEFAULT_CONFIG, "cards_response_size": str(self.expected_response_size)}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 300)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
-def mocked_get(*args, **kwargs):
+def mocked_get(status_code=None, json=None):
     '''
     Fake response object for the requests.request() used in the client
     '''
-    fake_response = requests.models.Response()
-    fake_response.headers.update(kwargs.get('headers', {}))
-    fake_response.status_code = kwargs['status_code']
-
-    # We can't set the content or text of the Response directly, so we mock a function
-    fake_response.json = Mock()
-    fake_response.json.side_effect = lambda:kwargs.get('json', {})
-    fake_response.raise_for_status = Mock()
-    fake_response.raise_for_status.side_effect = None
+    fake_response = mock.Mock()
+    fake_response.status_code = status_code
+    fake_response.json.return_value = json
+    fake_response.raise_for_status.return_value = None
 
     return fake_response
 
-def mock_build_custom_fields(**kwargs):
-    return [], []
 
-def mock_modify_rec(record, **kwargs):
-    return record
-    
 class TestCardPagination(unittest.TestCase):
     '''
     Test that pagination works correctly for cards
     '''
-    @mock.patch('tap_trello.client.requests.request', side_effect = [
-        mocked_get(status_code=200, json=[{"id": "60ca516249f04d4221b33450"}, {"id":"61973e91b41fcf475f84b351"}]), # 2 records for the first API call indicating 1st page
-        mocked_get(status_code=200, json=[{"id":"60c901a838d5f63c42d22044"}])]) # 1 record in the second API call indicating 2nd page with one record
-    @mock.patch('tap_trello.client.TrelloClient._get_member_id')
-    @mock.patch('tap_trello.streams.AddCustomFields.build_custom_fields_maps')
-    @mock.patch('tap_trello.streams.AddCustomFields.modify_record')
-    def test_pagination_on_cards(self, mock_modify_record, mock_custom_fields, mock_get_id, mock_request):
+    @mock.patch('tap_trello.client.requests.request')
+    def test_pagination_on_cards(self, mock_request):
         '''
         Test that the pagination works correctly setting the page size as 2, so getting a total of 3 records
         in the actual response
         '''
-        mock_custom_fields.side_effect = mock_build_custom_fields
-        mock_modify_record.side_effect = mock_modify_rec
+
+        mock_request.side_effect = [
+            # This is a call to `GET /members/me`
+            mocked_get(status_code=200, json={"id": 1}),
+            # This is a call to `GET /boards/{}/customFields`
+            mocked_get(status_code=200, json={}),
+            # 2 records for the first API call indicating 1st page
+            mocked_get(status_code=200, json=[{"id": "60ca516249f04d4221b33450", "customFieldItems": []},
+                                              {"id": "61973e91b41fcf475f84b351", "customFieldItems": []}]),
+            # 1 record in the second API call indicating 2nd page with one record
+            mocked_get(status_code=200, json=[{"id": "60c901a838d5f63c42d22044", "customFieldItems": []}]),
+        ]
+
         # config with the `cards_response_size` param set as 2
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 2}
+        config = {**DEFAULT_CONFIG, "cards_response_size": 2}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
         # a total of 3 records from the first call with 2 records as the `cards_response_size` is set to 2
         # and the second API call with one record indicating the break in the while loop
-        self.assertEqual(len(cards), 3)
+        self.assertEqual(3, len(cards))

--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -23,24 +23,24 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
 
     def test_default_param_value_for_cards(self, mock_request):
         '''
-        Test that when no config value is provided for `max_api_response_size_card`, then default is takn as 1000
+        Test that when no config value is provided for `max_api_response_size_card`, then default is takn as 5000
         '''
         config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs"}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(card.params['limit'], 5000)
 
     def test_empty_string_in_config(self, mock_request):
         '''
         Test that when empty string value is provided for the config param `max_api_response_size_card`, the default
-        value is taken and passed as 1000
+        value is taken and passed as 5000
         '''
         config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": ""}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(card.params['limit'], 5000)
 
     def test_string_value_in_config(self, mock_request):
         '''

--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest import mock
+from unittest.mock import Mock
+import requests
+from unittest.case import TestCase
+from tap_trello.client import LOGGER, TrelloClient
+from tap_trello.streams import Cards
+
+@mock.patch('tap_trello.client.requests.request')
+class TestMaxAPIResponseSizeValue(unittest.TestCase):
+    '''
+    Test that the max_api_response_size param is set correctly based on different config values
+    '''
+    def test_param_value_from_config_for_cards(self, mock_request):
+        '''
+        Test that when config parameter `max_api_response_size_card` is passed the params is set correctly from the config value
+        '''
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": 200}
+        client = TrelloClient(config)
+        card = Cards(client, config, {})
+        cards = list(card.get_records(['dummy']))
+        self.assertEqual(card.params['limit'], 200)
+
+    def test_default_param_value_for_cards(self, mock_request):
+        '''
+        Test that when no config value is provided for `max_api_response_size_card`, then default is takn as 1000
+        '''
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs"}
+        client = TrelloClient(config)
+        card = Cards(client, config, {})
+        cards = list(card.get_records(['dummy']))
+        self.assertEqual(card.params['limit'], 1000)
+
+    def test_empty_string_in_config(self, mock_request):
+        '''
+        Test that when empty string value is provided for the config param `max_api_response_size_card`, the default
+        value is taken and passed as 1000
+        '''
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": ""}
+        client = TrelloClient(config)
+        card = Cards(client, config, {})
+        cards = list(card.get_records(['dummy']))
+        self.assertEqual(card.params['limit'], 1000)
+
+    def test_string_value_in_config(self, mock_request):
+        '''
+        Test that when a string value is passe in the config param `max_api_response_size_card`, it is converted to integer
+        and then passed
+        '''
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": "300"}
+        client = TrelloClient(config)
+        card = Cards(client, config, {})
+        cards = list(card.get_records(['dummy']))
+        self.assertEqual(card.params['limit'], 300)
+
+def mocked_get(*args, **kwargs):
+    '''
+    Fake response object for the requests.request() used in the client
+    '''
+    fake_response = requests.models.Response()
+    fake_response.headers.update(kwargs.get('headers', {}))
+    fake_response.status_code = kwargs['status_code']
+
+    # We can't set the content or text of the Response directly, so we mock a function
+    fake_response.json = Mock()
+    fake_response.json.side_effect = lambda:kwargs.get('json', {})
+    fake_response.raise_for_status = Mock()
+    fake_response.raise_for_status.side_effect = None
+
+    return fake_response
+
+def mock_build_custom_fields(**kwargs):
+    return [], []
+
+def mock_modify_rec(record, **kwargs):
+    return record
+    
+class TestCardPagination(unittest.TestCase):
+    '''
+    Test that pagination works correctly for cards
+    '''
+    @mock.patch('tap_trello.client.requests.request', side_effect = [
+        mocked_get(status_code=200, json=[{"id": "60ca516249f04d4221b33450"}, {"id":"61973e91b41fcf475f84b351"}]), # 2 records for the first API call indicating 1st page
+        mocked_get(status_code=200, json=[{"id":"60c901a838d5f63c42d22044"}])]) # 1 record in the second API call indicating 2nd page with one record
+    @mock.patch('tap_trello.client.TrelloClient._get_member_id')
+    @mock.patch('tap_trello.streams.AddCustomFields.build_custom_fields_maps')
+    @mock.patch('tap_trello.streams.AddCustomFields.modify_record')
+    def test_pagination_on_cards(self, mock_modify_record, mock_custom_fields, mock_get_id, mock_request):
+        '''
+        Test that the pagination works correctly setting the page size as 2, so getting a total of 3 records
+        in the actual response
+        '''
+        mock_custom_fields.side_effect = mock_build_custom_fields
+        mock_modify_record.side_effect = mock_modify_rec
+        # config with the `max_api_response_size_card` param set as 2
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": 2}
+        client = TrelloClient(config)
+        card = Cards(client, config, {})
+        cards = list(card.get_records(['dummy']))
+        # a total of 3 records from the first call with 2 records as the `max_api_response_size_card` is set to 2
+        # and the second API call with one record indicating the break in the while loop
+        self.assertEqual(len(cards), 3)

--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -13,9 +13,9 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
     '''
     def test_param_value_from_config_for_cards(self, mock_request):
         '''
-        Test that when config parameter `max_api_response_size_card` is passed the params is set correctly from the config value
+        Test that when config parameter `cards_response_size` is passed the params is set correctly from the config value
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": 200}
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 200}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
@@ -23,31 +23,31 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
 
     def test_default_param_value_for_cards(self, mock_request):
         '''
-        Test that when no config value is provided for `max_api_response_size_card`, then default is takn as 5000
+        Test that when no config value is provided for `cards_response_size`, then default is taken as 1000
         '''
         config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs"}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 5000)
+        self.assertEqual(card.params['limit'], 1000)
 
     def test_empty_string_in_config(self, mock_request):
         '''
-        Test that when empty string value is provided for the config param `max_api_response_size_card`, the default
+        Test that when empty string value is provided for the config param `cards_response_size`, the default
         value is taken and passed as 5000
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": ""}
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": ""}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 5000)
+        self.assertEqual(card.params['limit'], 1000)
 
     def test_string_value_in_config(self, mock_request):
         '''
-        Test that when a string value is passe in the config param `max_api_response_size_card`, it is converted to integer
+        Test that when a string value is passe in the config param `cards_response_size`, it is converted to integer
         and then passed
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": "300"}
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": "300"}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
@@ -92,11 +92,11 @@ class TestCardPagination(unittest.TestCase):
         '''
         mock_custom_fields.side_effect = mock_build_custom_fields
         mock_modify_record.side_effect = mock_modify_rec
-        # config with the `max_api_response_size_card` param set as 2
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "max_api_response_size_card": 2}
+        # config with the `cards_response_size` param set as 2
+        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 2}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        # a total of 3 records from the first call with 2 records as the `max_api_response_size_card` is set to 2
+        # a total of 3 records from the first call with 2 records as the `cards_response_size` is set to 2
         # and the second API call with one record indicating the break in the while loop
         self.assertEqual(len(cards), 3)


### PR DESCRIPTION
# Description of change
[TDL-16246](https://jira.talendforge.org/browse/TDL-16246): Make MAX_API_RESPONSE_SIZE configurable
- Added support of configurable  parameter `cards_response_size`  in config file for card stream.(Default : 1000)
- Added pagination for the card stream.


# Manual QA steps
 - The verified output of the old tap with data emitted with a new approach for card stream.
- Provided limit in integer, and string format and verified that it's used in the request.

 
# Risks
 - Minimal. Test coverage suggests no issues with pagination.
 
# Rollback steps
 - revert this branch
