### PR TITLE
Improve the unit test

### DIFF
--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -14,18 +14,19 @@ DEFAULT_CONFIG = {
 }
 
 @mock.patch('tap_trello.client.requests.request')
-class TestMaxAPIResponseSizeValue(unittest.TestCase):
+class TestCardsResponseSizeValue(unittest.TestCase):
     '''
-    Test that the max_api_response_size param is set correctly based on different config values
+    Test that the cards_response_size param is set correctly based on different config values
     '''
 
     def setUp(self):
+        '''Reset the response size to a value in every test'''
         # This is the default in the tap
         self.expected_response_size = 1000
 
     def test_param_value_from_config_for_cards(self, mock_request):
         '''
-        Test that when config parameter `cards_response_size` is passed the params is set correctly from the config value
+        Test that when the config param `cards_response_size` is passed, it is used
         '''
         self.expected_response_size = 200
         config = {**DEFAULT_CONFIG, "cards_response_size": self.expected_response_size}
@@ -36,7 +37,8 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
 
     def test_default_param_value_for_cards(self, mock_request):
         '''
-        Test that when no config value is provided for `cards_response_size`, then default is taken as 1000
+        Test that when no config value is provided for the config param `cards_response_size`, then
+        the default is used
         '''
         client = TrelloClient(DEFAULT_CONFIG)
         card = Cards(client, DEFAULT_CONFIG, {})
@@ -45,8 +47,8 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
 
     def test_empty_string_in_config(self, mock_request):
         '''
-        Test that when empty string value is provided for the config param `cards_response_size`, the default
-        value is taken and passed as 5000
+        Test that when empty string value is provided for the config param `cards_response_size`, 
+        the default value is used
         '''
         config = {**DEFAULT_CONFIG, "cards_response_size": ""}
         client = TrelloClient(config)
@@ -56,8 +58,8 @@ class TestMaxAPIResponseSizeValue(unittest.TestCase):
 
     def test_string_value_in_config(self, mock_request):
         '''
-        Test that when a string value is passe in the config param `cards_response_size`, it is converted to integer
-        and then passed
+        Test that when a string value is passed in the config param `cards_response_size`, it is 
+        converted to integer and then used
         '''
         self.expected_response_size = 300
         config = {**DEFAULT_CONFIG, "cards_response_size": str(self.expected_response_size)}

--- a/tests/unittests/test_card_pagination.py
+++ b/tests/unittests/test_card_pagination.py
@@ -1,102 +1,111 @@
 import unittest
 from unittest import mock
-from unittest.mock import Mock
-import requests
 from unittest.case import TestCase
-from tap_trello.client import LOGGER, TrelloClient
+from tap_trello.client import TrelloClient
 from tap_trello.streams import Cards
+
+
+DEFAULT_CONFIG = {
+    "start_date": "dummy_st",
+    "access_token": "dummy_at",
+    "access_token_secret": "dummy_as",
+    "consumer_key": "dummy_ck",
+    "consumer_secret": "dummy_cs",
+}
 
 @mock.patch('tap_trello.client.requests.request')
 class TestMaxAPIResponseSizeValue(unittest.TestCase):
     '''
     Test that the max_api_response_size param is set correctly based on different config values
     '''
+
+    def setUp(self):
+        # This is the default in the tap
+        self.expected_response_size = 1000
+
     def test_param_value_from_config_for_cards(self, mock_request):
         '''
         Test that when config parameter `cards_response_size` is passed the params is set correctly from the config value
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 200}
+        self.expected_response_size = 200
+        config = {**DEFAULT_CONFIG, "cards_response_size": self.expected_response_size}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 200)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_default_param_value_for_cards(self, mock_request):
         '''
         Test that when no config value is provided for `cards_response_size`, then default is taken as 1000
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs"}
-        client = TrelloClient(config)
-        card = Cards(client, config, {})
+        client = TrelloClient(DEFAULT_CONFIG)
+        card = Cards(client, DEFAULT_CONFIG, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_empty_string_in_config(self, mock_request):
         '''
         Test that when empty string value is provided for the config param `cards_response_size`, the default
         value is taken and passed as 5000
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": ""}
+        config = {**DEFAULT_CONFIG, "cards_response_size": ""}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 1000)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
     def test_string_value_in_config(self, mock_request):
         '''
         Test that when a string value is passe in the config param `cards_response_size`, it is converted to integer
         and then passed
         '''
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": "300"}
+        self.expected_response_size = 300
+        config = {**DEFAULT_CONFIG, "cards_response_size": str(self.expected_response_size)}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
-        self.assertEqual(card.params['limit'], 300)
+        self.assertEqual(self.expected_response_size, card.params['limit'])
 
-def mocked_get(*args, **kwargs):
+def mocked_get(status_code=None, json=None):
     '''
     Fake response object for the requests.request() used in the client
     '''
-    fake_response = requests.models.Response()
-    fake_response.headers.update(kwargs.get('headers', {}))
-    fake_response.status_code = kwargs['status_code']
-
-    # We can't set the content or text of the Response directly, so we mock a function
-    fake_response.json = Mock()
-    fake_response.json.side_effect = lambda:kwargs.get('json', {})
-    fake_response.raise_for_status = Mock()
-    fake_response.raise_for_status.side_effect = None
+    fake_response = mock.Mock()
+    fake_response.status_code = status_code
+    fake_response.json.return_value = json
+    fake_response.raise_for_status.return_value = None
 
     return fake_response
 
-def mock_build_custom_fields(**kwargs):
-    return [], []
 
-def mock_modify_rec(record, **kwargs):
-    return record
-    
 class TestCardPagination(unittest.TestCase):
     '''
     Test that pagination works correctly for cards
     '''
-    @mock.patch('tap_trello.client.requests.request', side_effect = [
-        mocked_get(status_code=200, json=[{"id": "60ca516249f04d4221b33450"}, {"id":"61973e91b41fcf475f84b351"}]), # 2 records for the first API call indicating 1st page
-        mocked_get(status_code=200, json=[{"id":"60c901a838d5f63c42d22044"}])]) # 1 record in the second API call indicating 2nd page with one record
-    @mock.patch('tap_trello.client.TrelloClient._get_member_id')
-    @mock.patch('tap_trello.streams.AddCustomFields.build_custom_fields_maps')
-    @mock.patch('tap_trello.streams.AddCustomFields.modify_record')
-    def test_pagination_on_cards(self, mock_modify_record, mock_custom_fields, mock_get_id, mock_request):
+    @mock.patch('tap_trello.client.requests.request')
+    def test_pagination_on_cards(self, mock_request):
         '''
         Test that the pagination works correctly setting the page size as 2, so getting a total of 3 records
         in the actual response
         '''
-        mock_custom_fields.side_effect = mock_build_custom_fields
-        mock_modify_record.side_effect = mock_modify_rec
+
+        mock_request.side_effect = [
+            # This is a call to `GET /members/me`
+            mocked_get(status_code=200, json={"id": 1}),
+            # This is a call to `GET /boards/{}/customFields`
+            mocked_get(status_code=200, json={}),
+            # 2 records for the first API call indicating 1st page
+            mocked_get(status_code=200, json=[{"id": "60ca516249f04d4221b33450", "customFieldItems": []},
+                                              {"id": "61973e91b41fcf475f84b351", "customFieldItems": []}]),
+            # 1 record in the second API call indicating 2nd page with one record
+            mocked_get(status_code=200, json=[{"id": "60c901a838d5f63c42d22044", "customFieldItems": []}]),
+        ]
+
         # config with the `cards_response_size` param set as 2
-        config = {"start_date": "dummy_st","access_token": "dummy_at", "access_token_secret": "dummy_as", "consumer_key": "dummy_ck", "consumer_secret": "dummy_cs", "cards_response_size": 2}
+        config = {**DEFAULT_CONFIG, "cards_response_size": 2}
         client = TrelloClient(config)
         card = Cards(client, config, {})
         cards = list(card.get_records(['dummy']))
         # a total of 3 records from the first call with 2 records as the `cards_response_size` is set to 2
         # and the second API call with one record indicating the break in the while loop
-        self.assertEqual(len(cards), 3)
+        self.assertEqual(3, len(cards))


### PR DESCRIPTION
Dry up the unittest
1. Remove unused imports
2. Add a default config that each test uses
3. Use `setUp` to create a shared variable
4. Order assertions so it's (expected, actual)
5. Simplify the mocking to just one function
6. Simplify the API for `mocked_get`
