### PR TITLE
Move parameterized from install_requires to extras_require[dev]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.3
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 1.1.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-trello",
-    version="1.1.2",
+    version="1.1.3",
     description="Singer.io tap for extracting data from Trello API",
     author="Stitch",
     url="http://singer.io",
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_trello"],
     install_requires=[
         "singer-python==6.3.0",
-        "requests==2.32.5",
+        "requests==2.33.0",
         "backoff==2.2.1",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ setup(
         "singer-python==6.3.0",
         "requests==2.32.5",
         "backoff==2.2.1",
-        "parameterized"
     ],
     extras_require={
         'dev': [
             'ipdb',
+            'parameterized',
             'pylint',
             'pytest'
         ]


### PR DESCRIPTION
## Summary

`parameterized` is only used in test files (`tests/unittests/test_client.py`) and should not be included in the production image.

This moves it to `extras_require[dev]` where it will still be installed via `pip install .[dev]` in CI.